### PR TITLE
Added empty check for BSON marshaller

### DIFF
--- a/examples/custom-stringer/day_enum_marshal_bson.go
+++ b/examples/custom-stringer/day_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (day_enum Day) GetBSON() (interface{}, error) {
 
 func (day_enum *Day) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/day/day_enum_marshal_bson.go
+++ b/examples/day/day_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (day_enum Day) GetBSON() (interface{}, error) {
 
 func (day_enum *Day) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/multiple/biscuit_enum_marshal_bson.go
+++ b/examples/multiple/biscuit_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (biscuit_enum Biscuit) GetBSON() (interface{}, error) {
 
 func (biscuit_enum *Biscuit) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/multiple/cookie_enum_marshal_bson.go
+++ b/examples/multiple/cookie_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (cookie_enum Cookie) GetBSON() (interface{}, error) {
 
 func (cookie_enum *Cookie) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/multiple/singleFile/biscuit_and_cookies_biscuit_enum_marshal_bson.go
+++ b/examples/multiple/singleFile/biscuit_and_cookies_biscuit_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (biscuit_enum Biscuit) GetBSON() (interface{}, error) {
 
 func (biscuit_enum *Biscuit) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/multiple/singleFile/biscuit_and_cookies_cookie_enum_marshal_bson.go
+++ b/examples/multiple/singleFile/biscuit_and_cookies_cookie_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (cookie_enum Cookie) GetBSON() (interface{}, error) {
 
 func (cookie_enum *Cookie) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/examples/named/named_day_enum_marshal_bson.go
+++ b/examples/named/named_day_enum_marshal_bson.go
@@ -19,6 +19,10 @@ func (day_enum Day) GetBSON() (interface{}, error) {
 
 func (day_enum *Day) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {

--- a/templates/bson.tmpl
+++ b/templates/bson.tmpl
@@ -23,6 +23,10 @@ func ({{ $lt }} {{ $t }}) GetBSON() (interface{}, error) {
 
 func ({{ $lt }} *{{ $t }}) SetBSON(raw bson.Raw) error {
 	var str string
+
+	if len(raw.Data) == 0 {
+		return bson.ErrSetZero
+	}
 	
 	err := raw.Unmarshal(&str)
 	if err != nil {


### PR DESCRIPTION
In some cases you want to have a pointer enum so it can be a null value in a mongo database. If the object is then retrieved from the database en turned from the stored data to the enum but its a null value this function will get an empty `raw` argument. If this is then ran through the `raw.Unmarshal` function it will return an error kind of like: `Unknown element kind (0x00)` which is not something bson can handle easily. But an error like: "bson.ErrSetZero" is something it can handle. Thus adding this check and returning that error if the raw argument is empty. This will let the calling function now its zero and to handle it. https://github.com/globalsign/mgo/blob/eeefdecb41b8/bson/bson.go#L130    
https://go.dev/play/p/OlnsyC_xxjQ